### PR TITLE
change dep nearlib to near-api-js

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "typescript": "^3.8.3"
   },
   "dependencies": {
-    "nearlib": "^0.22.0",
+    "near-api-js": "^0.23.0",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "regenerator-runtime": "^0.13.5"
@@ -51,12 +51,16 @@
       {
         "displayName": "User interface tests",
         "testEnvironment": "jsdom",
-        "testMatch": ["<rootDir>/src/tests/ui/*.js"]
+        "testMatch": [
+          "<rootDir>/src/tests/ui/*.js"
+        ]
       },
       {
         "displayName": "Integration tests",
         "testEnvironment": "near-shell/test_environment",
-        "testMatch": ["<rootDir>/src/tests/integration/*.js"]
+        "testMatch": [
+          "<rootDir>/src/tests/integration/*.js"
+        ]
       }
     ],
     "testPathIgnorePatterns": [

--- a/src/index.js
+++ b/src/index.js
@@ -2,28 +2,28 @@ import React from 'react'
 import ReactDOM from 'react-dom'
 import App from './App'
 import getConfig from './config.js'
-import * as nearlib from 'nearlib'
+import * as nearAPIJs from 'near-api-js'
 
 // Initializing contract
 async function initContract () {
   const nearConfig = getConfig(process.env.NODE_ENV || 'development')
 
   // Initializing connection to the NEAR DevNet
-  const near = await nearlib.connect({
+  const near = await nearAPIJs.connect({
     deps: {
-      keyStore: new nearlib.keyStores.BrowserLocalStorageKeyStore()
+      keyStore: new nearAPIJs.keyStores.BrowserLocalStorageKeyStore()
     },
     ...nearConfig
   })
 
   // Needed to access wallet
-  const walletConnection = new nearlib.WalletConnection(near)
+  const walletConnection = new nearAPIJs.WalletConnection(near)
 
   // Get Account ID – if still unauthorized, it's an empty string
   const accountId = walletConnection.getAccountId()
 
   // Initializing our contract APIs by contract name and configuration
-  const contract = await new nearlib.Contract(walletConnection.account(), nearConfig.contractName, {
+  const contract = await new nearAPIJs.Contract(walletConnection.account(), nearConfig.contractName, {
     // View methods are read-only – they don't modify the state, but usually return some value
     viewMethods: ['getMessages'],
     // Change methods can modify the state, but you don't receive the returned value when called

--- a/src/index.js
+++ b/src/index.js
@@ -2,28 +2,28 @@ import React from 'react'
 import ReactDOM from 'react-dom'
 import App from './App'
 import getConfig from './config.js'
-import * as nearAPIJs from 'near-api-js'
+import * as nearAPI from 'near-api-js'
 
 // Initializing contract
 async function initContract () {
   const nearConfig = getConfig(process.env.NODE_ENV || 'development')
 
   // Initializing connection to the NEAR DevNet
-  const near = await nearAPIJs.connect({
+  const near = await nearAPI.connect({
     deps: {
-      keyStore: new nearAPIJs.keyStores.BrowserLocalStorageKeyStore()
+      keyStore: new nearAPI.keyStores.BrowserLocalStorageKeyStore()
     },
     ...nearConfig
   })
 
   // Needed to access wallet
-  const walletConnection = new nearAPIJs.WalletConnection(near)
+  const walletConnection = new nearAPI.WalletConnection(near)
 
   // Get Account ID – if still unauthorized, it's an empty string
   const accountId = walletConnection.getAccountId()
 
   // Initializing our contract APIs by contract name and configuration
-  const contract = await new nearAPIJs.Contract(walletConnection.account(), nearConfig.contractName, {
+  const contract = await new nearAPI.Contract(walletConnection.account(), nearConfig.contractName, {
     // View methods are read-only – they don't modify the state, but usually return some value
     viewMethods: ['getMessages'],
     // Change methods can modify the state, but you don't receive the returned value when called

--- a/yarn.lock
+++ b/yarn.lock
@@ -5689,6 +5689,22 @@ ncp@^2.0.0:
   resolved "https://registry.yarnpkg.com/ncp/-/ncp-2.0.0.tgz#195a21d6c46e361d2fb1281ba38b91e9df7bdbb3"
   integrity sha1-GVoh1sRuNh0vsSgbo4uR6d9727M=
 
+near-api-js@^0.23.0:
+  version "0.23.0"
+  resolved "https://registry.yarnpkg.com/near-api-js/-/near-api-js-0.23.0.tgz#422108b33ecfd824e645473997ba00c9f45e0bf2"
+  integrity sha512-rGEgQdjtY9JdwaveDOEauB1voH7eTGM41cJettBO8MKbxPl4obCEiaQAhA80TxJ1I8t3LQhvbI6B8+/EitaeUw==
+  dependencies:
+    "@types/bn.js" "^4.11.5"
+    bn.js "^5.0.0"
+    bs58 "^4.0.0"
+    error-polyfill "^0.1.2"
+    http-errors "^1.7.2"
+    js-sha256 "^0.9.0"
+    mustache "^4.0.0"
+    node-fetch "^2.3.0"
+    text-encoding-utf-8 "^1.0.2"
+    tweetnacl "^1.0.1"
+
 near-bindgen-as@^1.3.1-1:
   version "1.3.1-1"
   resolved "https://registry.yarnpkg.com/near-bindgen-as/-/near-bindgen-as-1.3.1-1.tgz#67572fd531536147d5f4b697a907da1b063c0281"


### PR DESCRIPTION
Small PR using `near-api-js`
Note: the tests still reference `nearlib` and it's still in the `yarn.lock` because `near-shell` needs to change the `test_environment` as mentioned here:
https://github.com/nearprotocol/near-shell/issues/312