### PR TITLE
fix near-bindgen-as reference to near-sdk-as

### DIFF
--- a/asconfig.js
+++ b/asconfig.js
@@ -1,4 +1,4 @@
-const compile = require('near-bindgen-as/compiler').compile
+const compile = require('near-sdk-as/compiler').compile
 
 compile('assembly/main.ts', // input file
   'out/main.wasm', // output file


### PR DESCRIPTION
Looks like we missed fixing a reference here.
Once this is merged, we can `@dependabot rebase` this PR:
https://github.com/near-examples/guest-book/pull/71