### PR TITLE
fix: update gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,9 +10,7 @@ neardev/shared-test/*
 
 # ignore any default network private keys and dev-account
 neardev/default/*
-neardev/dev-account
+neardev/dev-account*
 
 # misc
 yarn-error.log
-.DS_Store
-.idea


### PR DESCRIPTION
* now needs to ignore neardev/dev-account.env
* remove env-specific files, which should go in users' global gitignore files (`~/.gitignore`), not in specific repositories