### PR TITLE
refactor: rm neardev/default from git

### DIFF
--- a/neardev/default/dev-1582817300252.json
+++ b/neardev/default/dev-1582817300252.json
@@ -1,1 +1,0 @@
-{"account_id":"dev-1582817300252","private_key":"ed25519:2MpYmwAnKum3qGR6ggwgXozSR6Er5Z9bzD72LsT8DgrgUuYA37aQ4uPj1oHZdRxbNpuwnGxRcGBk9CsCrDEcG1ki"}


### PR DESCRIPTION
This directory is gitignored but an old key had been checked into the repo by mistake