### PR TITLE
refactor: add id to each message

### DIFF
--- a/assembly/__tests__/guestbook.spec.ts
+++ b/assembly/__tests__/guestbook.spec.ts
@@ -1,47 +1,40 @@
 import { addMessage, getMessages } from '../main'
 import { PostedMessage, messages } from '../model'
 
+afterEach( () => {
+  while (messages.length > 0) {
+    messages.pop()
+  }
+})
 
-function createMessage (text: string): PostedMessage {
-  return new PostedMessage(text);
-}
-
-const hello: string = 'hello world'
-const message = createMessage(hello)
-
-describe('messages should be able to', () => {
-  beforeEach(()  => {
-    addMessage(hello)
-  });
-
-  afterEach( () => {
-    while (messages.length > 0) {
-      messages.pop()
-    }
-  })
-
-  it('add a message', () => {
+describe('addMessage', () => {
+  it('adds a message to the PersistentVector', () => {
+    addMessage('some unique id', 'hey')
     expect(messages.length).toBe(1, 'should only contain one message')
-    expect(messages[0]).toStrictEqual(message, 'message should be "hello world"')
+    expect(messages[0].id).toBe('some unique id')
+    expect(messages[0].text).toBe('hey')
   })
+})
 
-  it('retrive messages', () => {
+describe('getMessages', () => {
+  it('returns an array of messages', () => {
+    addMessage('another unique id', 'hey')
     const messagesArr = getMessages()
-    expect(messagesArr.length).toBe(1, 'should be one message')
-    expect(messagesArr).toIncludeEqual(message, 'messages should include:\n' + message.toJSON())
-    log(messagesArr[0])
+    assert(Array.isArray(messagesArr))
+    expect(messagesArr.length).toBe(1)
+    expect(messagesArr[0].id).toBe('another unique id')
+    expect(messagesArr[0].text).toBe('hey')
   })
 
-  it('only show the last ten messages', () => {
-    const newMessages: PostedMessage[] = []
-    for (let i: i32 = 0; i < 10; i++) {
+  it('only shows the last ten messages', () => {
+    for (let i: i32 = 0; i < 11; i++) {
+      const id = i.toString()
       const text = 'message #' + i.toString()
-      newMessages.push(createMessage(text))
-      addMessage(text)
+      addMessage(id, text)
     }
-    const messages = getMessages()
-    log(messages.slice(7, 10))
-    expect(messages).toStrictEqual(newMessages, 'should be the last ten mesages')
-    expect(messages).not.toIncludeEqual(message, "shouldn't contain the first element")
+    const messagesArr = getMessages()
+    expect(messagesArr.length).toBe(10)
+    const messageIDs: string[] = messagesArr.map<string>(m => m.id)
+    expect(messageIDs).not.toIncludeEqual('0', "shouldn't contain the first element")
   })
 })

--- a/assembly/main.ts
+++ b/assembly/main.ts
@@ -10,9 +10,9 @@ const MESSAGE_LIMIT = 10;
  * NOTE: This is a change method. Which means it will modify the state.\
  * But right now we don't distinguish them with annotations yet.
  */
-export function addMessage(text: string): void {
+export function addMessage(id: string, text: string): void {
   // Creating a new message and populating fields with our data
-  const message = new PostedMessage(text);
+  const message = new PostedMessage(id, text);
   // Adding the message to end of the the persistent collection
   messages.push(message);
 }
@@ -20,7 +20,7 @@ export function addMessage(text: string): void {
 /**
  * Returns an array of last N messages.\
  * NOTE: This is a view method. Which means it should NOT modify the state.
- */ 
+ */
 export function getMessages(): PostedMessage[] {
   const numMessages = min(MESSAGE_LIMIT, messages.length);
   const startIndex = messages.length - numMessages;

--- a/assembly/model.ts
+++ b/assembly/model.ts
@@ -1,18 +1,18 @@
 import { context, u128, PersistentVector } from "near-sdk-as";
 
-/** 
+/**
  * Exporting a new class PostedMessage so it can be used outside of this file.
  */
 @nearBindgen
 export class PostedMessage {
   premium: boolean;
   sender: string;
-  constructor(public text: string) {
+  constructor(public id: string, public text: string) {
     this.premium = context.attachedDeposit >= u128.from('10000000000000000000000');
     this.sender = context.sender;
   }
 }
-/** 
+/**
  * collections.vector is a persistent collection. Any changes to it will
  * be automatically saved in the storage.
  * The parameter to the constructor needs to be unique across a single contract.

--- a/package.json
+++ b/package.json
@@ -45,7 +45,8 @@
     "near-api-js": "^0.24.0",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
-    "regenerator-runtime": "^0.13.5"
+    "regenerator-runtime": "^0.13.5",
+    "uuid": "^8.0.0"
   },
   "jest": {
     "projects": [

--- a/src/App.js
+++ b/src/App.js
@@ -2,6 +2,7 @@ import 'regenerator-runtime/runtime'
 import React, { useCallback, useEffect, useState } from 'react'
 import PropTypes from 'prop-types'
 import Big from 'big.js'
+import { v4 as uuid } from 'uuid'
 
 const SUGGESTED_DONATION = '1'
 const BOATLOAD_OF_GAS = Big(1).times(10 ** 16).toFixed()
@@ -23,9 +24,11 @@ const App = ({ contract, currentUser, nearConfig, wallet }) => {
 
     // TODO: optimistically update page with new message,
     // update blockchain data in background
-    // add uuid to each message, so we know which one is already known
     contract.addMessage(
-      { text: message.value },
+      {
+        id: uuid(),
+        text: message.value
+      },
       BOATLOAD_OF_GAS,
       Big(donation.value || '0').times(10 ** 24).toFixed()
     ).then(() => {

--- a/src/tests/integration/App-integration.test.js
+++ b/src/tests/integration/App-integration.test.js
@@ -19,9 +19,10 @@ beforeAll(async function () {
 })
 
 it('send one message and retrieve it', async () => {
-  await contract.addMessage({ text: 'aloha' })
+  await contract.addMessage({ id: '1', text: 'aloha' })
   const msgs = await contract.getMessages()
   const expectedMessagesResult = [{
+    id: '1',
     premium: false,
     sender: accountId,
     text: 'aloha'
@@ -30,8 +31,8 @@ it('send one message and retrieve it', async () => {
 })
 
 it('send two more messages and expect three total', async () => {
-  await contract.addMessage({ text: 'foo' })
-  await contract.addMessage({ text: 'bar' })
+  await contract.addMessage({ id: '2', text: 'foo' })
+  await contract.addMessage({ id: '3', text: 'bar' })
   const msgs = await contract.getMessages()
   expect(msgs.length).toEqual(3)
 })


### PR DESCRIPTION
* Add id to each message stored on-chain (see changes in assembly directory)
* Create this id using a uuid library on the frontend

This lays the groundwork for doing optimistic UI updates, such as those being explored in #79