### PR TITLE
additional instructions to README for gh-pages auto deploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,17 @@ Modify the line in `src/config.js` that sets the account name of the contract. S
     const CONTRACT_NAME = process.env.CONTRACT_NAME || 'your-account-here!'
 
 
-Step 3: deploy!
+Step 3: change remote URL if you cloned this repo 
+-------------------------
+
+Unless you forked this repository you will need to change the remote URL to a repo that you have commit access to. This will allow auto deployment to Github Pages from the command line.
+
+1) go to GitHub and create a new repository for this project
+2) open your terminal and in the root of this project enter the following:
+    $ `git remote set-url origin https://github.com/YOUR_USERNAME/YOUR_REPOSITORY.git`
+
+
+Step 4: deploy!
 ---------------
 
 One command:

--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ Unless you forked this repository you will need to change the remote URL to a re
 
 1) go to GitHub and create a new repository for this project
 2) open your terminal and in the root of this project enter the following:
+
     $ `git remote set-url origin https://github.com/YOUR_USERNAME/YOUR_REPOSITORY.git`
 
 


### PR DESCRIPTION
Auto deployment to GitHub Pages will not work if someone clones this repo instead of forking. In order for auto-deployment to work, the user has to update the remote URL. 

This PR updates the README file to include instructions on how to complete this task / notifying them of the need to do so.