### PR TITLE
Update .gitpod.yml to default to node

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -20,8 +20,8 @@ github:
 
 # List the start up tasks. You can start them in parallel in multiple terminals. See https://www.gitpod.io/docs/config-start-tasks/
 tasks:
-  - before: nvm use default
-    command: gp open README-Gitpod.md && yarn && alias near=./node_modules/near-shell/bin/near && yarn dev
+  - before: echo "nvm use default" >> ~/.bashrc && nvm use default
+    command: source ~/.bashrc; gp open README-Gitpod.md && yarn && alias near=./node_modules/near-shell/bin/near && yarn dev
 
 ports:
   - port: 1234


### PR DESCRIPTION
This PR updates the `.gitpod.yml` file to set node as default. Prior to this, user would have to type nvm use default when opening new terminal windows in Gitpod.