### PR TITLE
config.js update for GitHub Pages deployment

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -2,7 +2,6 @@ const CONTRACT_NAME = process.env.CONTRACT_NAME || 'guest-book.testnet'
 
 function getConfig (env) {
   switch (env) {
-    case 'production':
     case 'mainnet':
       return {
         networkId: 'mainnet',
@@ -11,6 +10,7 @@ function getConfig (env) {
         walletUrl: 'https://wallet.near.org',
         helperUrl: 'https://helper.mainnet.near.org'
       }
+    case 'production':
     case 'development':
     case 'testnet':
       return {

--- a/src/config.js
+++ b/src/config.js
@@ -10,6 +10,8 @@ function getConfig (env) {
         walletUrl: 'https://wallet.near.org',
         helperUrl: 'https://helper.mainnet.near.org'
       }
+    // This is an example app so production is set to testnet.
+    // You can move production to mainnet if that is applicable.
     case 'production':
     case 'development':
     case 'testnet':


### PR DESCRIPTION
**Objective:**
1) To have a deployed version of this repository on GitHub Pages that users can interact with. 
2) Contract should be built and deployed to the NEAR `testnet` network.

**Issue:**
Network configuration is set to `mainnet` via the Parcel build `NODE_ENV` which is currently set to `production`.

**Solution Options:**
1) In `src/config.js` move the case for `production` to line 13 which will return `testnet` configuration settings.
2) In `src/config.js` comment out `mainnet` code block (lines 5-12) and leave comments in code explaining this.
3) Modify the Parcel build `NODE_ENV` to `testnet`.

Currently, this PR is for solution 1, but certainly can be modified to another solution pending feedback / consensus.